### PR TITLE
Don't highlight keywords embedded in symbols, e.g. start-task.

### DIFF
--- a/pddl-mode.el
+++ b/pddl-mode.el
@@ -97,7 +97,7 @@
 				    "when" "assign" "scale-up" "scale-down"
 				    "increase" "decrease" "start" "end" "all"
 				    "at" "over" "minimize" "maximize"
-				    "total-time") 'words)
+				    "total-time") 'symbols)
 		      'font-lock-keyword-face)))
   "Additional Keywords to highlight in PDDL mode")
 


### PR DESCRIPTION
Here's a comparison of the highlighting before and after this change. Notice that `start` in `ict-press-start-button` is no longer highlighted.

![pddl-anim](https://user-images.githubusercontent.com/52466/40379002-eaa32ea2-5da9-11e8-9164-ac29a0b808f3.gif)

