### PR TITLE
UPDATE fix auto-mode-alist for ".pddl" file

### DIFF
--- a/pddl-mode.el
+++ b/pddl-mode.el
@@ -76,7 +76,7 @@
     PDDL-mode-map)
   "Keymap for PDDL major mode")
 
-(add-to-list 'auto-mode-alist '("\\.PDDL\\'".PDDL-mode))
+(add-to-list 'auto-mode-alist '("\\.PDDL\\'" . PDDL-mode))
 
 (defconst PDDL-font-lock-keywords-1
   (list (cons "\\(\\(^\\|[^\\\\\n]\\)\\(\\\\\\\\\\)*\\);+.*$"


### PR DESCRIPTION
GNU Emacs 26.3
the pddl file weren't recognized by the mode
(dotted notation)